### PR TITLE
Max session error handling added.

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -109,7 +109,7 @@ func NewSSHSession(conn net.Conn, config *ssh.ClientConfig) (*Session, error) {
 		return nil, err
 	}
 
-	return NewSession(t), nil
+	return NewSession(t)
 }
 
 // DialSSH creates a new NETCONF session using a SSH Transport.
@@ -120,7 +120,7 @@ func DialSSH(target string, config *ssh.ClientConfig) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewSession(&t), nil
+	return NewSession(&t)
 }
 
 // DialSSHTimeout creates a new NETCONF session using a SSH Transport with timeout.
@@ -149,7 +149,7 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 		}
 	}()
 
-	return NewSession(t), nil
+	return NewSession(t)
 }
 
 // SSHConfigPassword is a convenience function that takes a username and password

--- a/netconf/transport_telnet.go
+++ b/netconf/transport_telnet.go
@@ -57,5 +57,5 @@ func DialTelnet(target string, username string, password string, vendor VendorIO
 	if err := t.Dial(target, username, password, vendor); err != nil {
 		return nil, err
 	}
-	return NewSession(&t), nil
+	return NewSession(&t)
 }


### PR DESCRIPTION
When trying to dial to an extreme networks switch where maximum netconf sessions are already connected (16), the following error occurs and capabilities are not exchanged.  However, go-netconf does not report the error and dial/dialTimeout incorrectly succeed. 

Example of error reported with max netconf sessions:
=========================================== 
badaniya@BADANIYA-PC:~$ ssh admin@10.24.12.127 -s netconf
admin@10.24.12.127's password: 
X11 forwarding request failed on channel 0
<!-- Error: Too many sessions. (closing session) -->
